### PR TITLE
Expose API endpoints in Swagger

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -14,12 +14,15 @@
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Api/Controllers/QuotesController.cs
+++ b/src/Api/Controllers/QuotesController.cs
@@ -1,19 +1,36 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Api.Background;
 
 namespace Api.Controllers;
 
+/// <summary>
+/// Provides market quote endpoints.
+/// </summary>
 [ApiController]
 [Route("api/[controller]")]
+[ApiExplorerSettings(GroupName = "Quotes")]
 public class QuotesController : ControllerBase
 {
+    /// <summary>
+    /// Gets the latest quotes for all tracked symbols.
+    /// </summary>
+    /// <returns>A collection of quotes keyed by symbol.</returns>
     [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
     public IActionResult GetQuotes()
     {
         return Ok(FinnhubRestService.LatestQuotes);
     }
 
+    /// <summary>
+    /// Gets the latest quote for a specified symbol.
+    /// </summary>
+    /// <param name="symbol">Ticker symbol.</param>
+    /// <returns>The latest quote if available.</returns>
     [HttpGet("{symbol}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public IActionResult GetQuote(string symbol)
     {
         if (FinnhubRestService.LatestQuotes.TryGetValue(symbol, out var quote))


### PR DESCRIPTION
## Summary
- enable XML documentation generation and wire into Swagger
- document and tag QuotesController actions so they surface in Swagger

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68986a893460832bb215e90494af05de