### PR TITLE
Add Finnhub market data endpoints and client

### DIFF
--- a/src/Api/Background/FinnhubRestService.cs
+++ b/src/Api/Background/FinnhubRestService.cs
@@ -2,7 +2,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.SignalR;
-using Api.DTOs;
+using Domain.DTOs;
 using Api.Hubs;
 
 namespace Api.Background;

--- a/src/Api/Controllers/OrderBookController.cs
+++ b/src/Api/Controllers/OrderBookController.cs
@@ -1,0 +1,36 @@
+using Domain.DTOs;
+using Infrastructure.Clients;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// Provides order book data.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[ApiExplorerSettings(GroupName = "Market")]
+public class OrderBookController : ControllerBase
+{
+    private readonly IFinnhubClient _client;
+
+    public OrderBookController(IFinnhubClient client)
+    {
+        _client = client;
+    }
+
+    /// <summary>
+    /// Returns the current order book for a symbol.
+    /// </summary>
+    /// <param name="symbol">The market symbol.</param>
+    /// <param name="depth">Optional depth.</param>
+    [HttpGet("{symbol}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<FinnhubOrderBookDto>> Get(string symbol, [FromQuery] int? depth)
+    {
+        var book = await _client.GetOrderBookAsync(symbol, depth);
+        if (book == null) return NotFound();
+        return Ok(book);
+    }
+}

--- a/src/Api/Controllers/SnapshotController.cs
+++ b/src/Api/Controllers/SnapshotController.cs
@@ -1,0 +1,35 @@
+using Domain.DTOs;
+using Infrastructure.Clients;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// Provides quote snapshots.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[ApiExplorerSettings(GroupName = "Market")]
+public class SnapshotController : ControllerBase
+{
+    private readonly IFinnhubClient _client;
+
+    public SnapshotController(IFinnhubClient client)
+    {
+        _client = client;
+    }
+
+    /// <summary>
+    /// Returns the latest quote snapshot.
+    /// </summary>
+    /// <param name="symbol">The market symbol.</param>
+    [HttpGet("{symbol}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<FinnhubQuoteDto>> Get(string symbol)
+    {
+        var snap = await _client.GetQuoteAsync(symbol);
+        if (snap == null) return NotFound();
+        return Ok(snap);
+    }
+}

--- a/src/Api/Controllers/TradesController.cs
+++ b/src/Api/Controllers/TradesController.cs
@@ -1,0 +1,42 @@
+using Domain.DTOs;
+using Infrastructure.Clients;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// Provides recent trade data.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[ApiExplorerSettings(GroupName = "Market")]
+public class TradesController : ControllerBase
+{
+    private readonly IFinnhubClient _client;
+
+    public TradesController(IFinnhubClient client)
+    {
+        _client = client;
+    }
+
+    /// <summary>
+    /// Returns trades for a symbol within a time range.
+    /// </summary>
+    /// <param name="symbol">The market symbol.</param>
+    /// <param name="from">Start time in UTC.</param>
+    /// <param name="to">End time in UTC.</param>
+    /// <param name="limit">Optional limit.</param>
+    [HttpGet("{symbol}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<FinnhubTradeDto>> Get(string symbol, [FromQuery] DateTime from, [FromQuery] DateTime to, [FromQuery] int? limit)
+    {
+        if (from == default || to == default)
+            return BadRequest("from and to are required");
+
+        var trades = await _client.GetTradesAsync(symbol, from, to, limit);
+        if (trades == null) return NotFound();
+        return Ok(trades);
+    }
+}

--- a/src/Api/Hubs/MarketHub.cs
+++ b/src/Api/Hubs/MarketHub.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace Api.Hubs;
+
+/// <summary>
+/// Hub providing market data streams.
+/// </summary>
+public class MarketHub : Hub
+{
+    /// <summary>
+    /// Subscribe the current connection to a symbol's updates.
+    /// </summary>
+    public Task Subscribe(string symbol) => Groups.AddToGroupAsync(Context.ConnectionId, symbol);
+
+    /// <summary>
+    /// Unsubscribe the current connection from a symbol's updates.
+    /// </summary>
+    public Task Unsubscribe(string symbol) => Groups.RemoveFromGroupAsync(Context.ConnectionId, symbol);
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -5,6 +5,7 @@ using Domain.Services;
 using FluentValidation;
 using FluentValidation.AspNetCore;
 using Infrastructure;
+using Infrastructure.Clients;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Api.Background;
@@ -32,6 +33,7 @@ builder.Services.AddControllers();
 builder.Services.AddSignalR();
 builder.Services.AddHttpClient<FinnhubRestService>();
 builder.Services.AddHostedService<FinnhubRestService>();
+builder.Services.AddHttpClient<IFinnhubClient, FinnhubClient>();
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
@@ -109,6 +111,7 @@ app.MapGet("/v1/allowances/{canton}/{year:int}", async (string canton, int year,
    .WithOpenApi();
 
 app.MapHub<QuotesHub>("/quotesHub");
+app.MapHub<MarketHub>("/hubs/market");
 app.MapControllers();
 
 app.Run();

--- a/src/Domain/DTOs/FinnhubOrderBookDto.cs
+++ b/src/Domain/DTOs/FinnhubOrderBookDto.cs
@@ -1,0 +1,27 @@
+namespace Domain.DTOs;
+
+/// <summary>
+/// Represents a level 2 order book snapshot returned by Finnhub.
+/// </summary>
+public class FinnhubOrderBookDto
+{
+    /// <summary>
+    /// Bids in the book expressed as [price, size].
+    /// </summary>
+    public decimal[][] b { get; set; } = Array.Empty<decimal[]>();
+
+    /// <summary>
+    /// Asks in the book expressed as [price, size].
+    /// </summary>
+    public decimal[][] a { get; set; } = Array.Empty<decimal[]>();
+
+    /// <summary>
+    /// Unix timestamp of the snapshot.
+    /// </summary>
+    public long t { get; set; }
+
+    /// <summary>
+    /// Symbol of the book.
+    /// </summary>
+    public string s { get; set; } = string.Empty;
+}

--- a/src/Domain/DTOs/FinnhubQuoteDto.cs
+++ b/src/Domain/DTOs/FinnhubQuoteDto.cs
@@ -1,4 +1,4 @@
-namespace Api.DTOs;
+namespace Domain.DTOs;
 
 public class FinnhubQuoteDto
 {

--- a/src/Domain/DTOs/FinnhubTradeDto.cs
+++ b/src/Domain/DTOs/FinnhubTradeDto.cs
@@ -1,0 +1,43 @@
+namespace Domain.DTOs;
+
+/// <summary>
+/// Represents trade ticks returned by Finnhub.
+/// </summary>
+public class FinnhubTradeDto
+{
+    /// <summary>
+    /// Symbol for the trades.
+    /// </summary>
+    public string s { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Collection of trade ticks.
+    /// </summary>
+    public IEnumerable<FinnhubTradeTick> data { get; set; } = Enumerable.Empty<FinnhubTradeTick>();
+}
+
+/// <summary>
+/// Individual trade tick information.
+/// </summary>
+public class FinnhubTradeTick
+{
+    /// <summary>
+    /// Trade price.
+    /// </summary>
+    public decimal p { get; set; }
+
+    /// <summary>
+    /// Trade volume.
+    /// </summary>
+    public decimal v { get; set; }
+
+    /// <summary>
+    /// Unix timestamp of the trade.
+    /// </summary>
+    public long t { get; set; }
+
+    /// <summary>
+    /// Optional trade conditions.
+    /// </summary>
+    public IEnumerable<string>? c { get; set; }
+}

--- a/src/Infrastructure/Clients/FinnhubClient.cs
+++ b/src/Infrastructure/Clients/FinnhubClient.cs
@@ -1,0 +1,41 @@
+using System.Net.Http.Json;
+using Domain.DTOs;
+using Microsoft.Extensions.Configuration;
+
+namespace Infrastructure.Clients;
+
+/// <summary>
+/// Lightweight HTTP client for Finnhub's REST API.
+/// </summary>
+public class FinnhubClient : IFinnhubClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _apiKey;
+
+    public FinnhubClient(HttpClient httpClient, IConfiguration configuration)
+    {
+        _httpClient = httpClient;
+        _apiKey = configuration["FINNHUB_API_KEY"] ?? string.Empty;
+        _httpClient.BaseAddress = new Uri("https://finnhub.io/api/v1/");
+    }
+
+    public async Task<FinnhubOrderBookDto?> GetOrderBookAsync(string symbol, int? depth = null, CancellationToken ct = default)
+    {
+        var url = $"orderbook?symbol={symbol}&token={_apiKey}";
+        if (depth.HasValue) url += $"&depth={depth.Value}";
+        return await _httpClient.GetFromJsonAsync<FinnhubOrderBookDto>(url, ct);
+    }
+
+    public async Task<FinnhubTradeDto?> GetTradesAsync(string symbol, DateTime from, DateTime to, int? limit = null, CancellationToken ct = default)
+    {
+        var url = $"stock/trades?symbol={symbol}&from={from:yyyy-MM-dd}&to={to:yyyy-MM-dd}&token={_apiKey}";
+        if (limit.HasValue) url += $"&limit={limit.Value}";
+        return await _httpClient.GetFromJsonAsync<FinnhubTradeDto>(url, ct);
+    }
+
+    public Task<FinnhubQuoteDto?> GetQuoteAsync(string symbol, CancellationToken ct = default)
+    {
+        var url = $"quote?symbol={symbol}&token={_apiKey}";
+        return _httpClient.GetFromJsonAsync<FinnhubQuoteDto>(url, ct);
+    }
+}

--- a/src/Infrastructure/Clients/IFinnhubClient.cs
+++ b/src/Infrastructure/Clients/IFinnhubClient.cs
@@ -1,0 +1,10 @@
+using Domain.DTOs;
+
+namespace Infrastructure.Clients;
+
+public interface IFinnhubClient
+{
+    Task<FinnhubOrderBookDto?> GetOrderBookAsync(string symbol, int? depth = null, CancellationToken ct = default);
+    Task<FinnhubTradeDto?> GetTradesAsync(string symbol, DateTime from, DateTime to, int? limit = null, CancellationToken ct = default);
+    Task<FinnhubQuoteDto?> GetQuoteAsync(string symbol, CancellationToken ct = default);
+}

--- a/tests/ApiTests/MarketControllersTests.cs
+++ b/tests/ApiTests/MarketControllersTests.cs
@@ -1,0 +1,27 @@
+using Api.Controllers;
+using Domain.DTOs;
+using Infrastructure.Clients;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+using Xunit;
+
+class FakeFinnhubClient : IFinnhubClient
+{
+    public Task<FinnhubOrderBookDto?> GetOrderBookAsync(string symbol, int? depth = null, CancellationToken ct = default)
+        => Task.FromResult<FinnhubOrderBookDto?>(new FinnhubOrderBookDto());
+    public Task<FinnhubTradeDto?> GetTradesAsync(string symbol, DateTime from, DateTime to, int? limit = null, CancellationToken ct = default)
+        => Task.FromResult<FinnhubTradeDto?>(new FinnhubTradeDto());
+    public Task<FinnhubQuoteDto?> GetQuoteAsync(string symbol, CancellationToken ct = default)
+        => Task.FromResult<FinnhubQuoteDto?>(new FinnhubQuoteDto());
+}
+
+public class MarketControllersTests
+{
+    [Fact]
+    public async Task OrderBook_ReturnsOk()
+    {
+        var controller = new OrderBookController(new FakeFinnhubClient());
+        var result = await controller.Get("AAPL", null);
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+}


### PR DESCRIPTION
## Summary
- add Finnhub HTTP client and interface
- expose order book, trades, and snapshot endpoints
- register new market SignalR hub

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6898b0286e80832bb3ddab369170665b