### PR TITLE
Add Finnhub options and market DTO pipeline

### DIFF
--- a/src/Api/Controllers/CandlesController.cs
+++ b/src/Api/Controllers/CandlesController.cs
@@ -1,0 +1,28 @@
+using Domain.DTOs;
+using Domain.Services;
+using Infrastructure.Clients;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[ApiExplorerSettings(GroupName = "Market")]
+public class CandlesController : ControllerBase
+{
+    private readonly IFinnhubClient _client;
+    public CandlesController(IFinnhubClient client) { _client = client; }
+
+    /// <summary>Returns historical candlesticks.</summary>
+    [HttpGet("{symbol}")]
+    [SwaggerOperation(Summary = "Returns historical candlesticks.")]
+    [ProducesResponseType(typeof(FinnhubCandleDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<FinnhubCandleDto>> Get(string symbol, [FromQuery] string resolution, [FromQuery] DateTime from, [FromQuery] DateTime to)
+    {
+        var norm = SymbolNormalizer.Normalize(symbol);
+        var candles = await _client.GetCandlesAsync(norm, resolution, from, to);
+        if (candles == null) return NotFound();
+        return Ok(candles);
+    }
+}

--- a/src/Api/Controllers/OrderBookController.cs
+++ b/src/Api/Controllers/OrderBookController.cs
@@ -1,6 +1,8 @@
 using Domain.DTOs;
+using Domain.Services;
 using Infrastructure.Clients;
 using Microsoft.AspNetCore.Mvc;
+using System.Linq;
 using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Filters;
 using Api.SwaggerExamples;
@@ -29,15 +31,36 @@ public class OrderBookController : ControllerBase
     /// <param name="depth">Optional depth.</param>
     [HttpGet("{symbol}")]
     [SwaggerOperation(Summary = "Returns the current order book for a symbol.")]
-    [ProducesResponseType(typeof(FinnhubOrderBookDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OrderBookDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [SwaggerResponse(StatusCodes.Status200OK, "Order book snapshot", typeof(FinnhubOrderBookDto))]
+    [SwaggerResponse(StatusCodes.Status200OK, "Order book snapshot", typeof(OrderBookDto))]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Book not found")]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(OrderBookExample))]
-    public async Task<ActionResult<FinnhubOrderBookDto>> Get(string symbol, [FromQuery] int? depth)
+    public async Task<ActionResult<OrderBookDto>> Get(string symbol, [FromQuery] int? depth)
     {
-        var book = await _client.GetOrderBookAsync(symbol, depth);
+        var norm = SymbolNormalizer.Normalize(symbol);
+        var book = await _client.GetOrderBookAsync(norm, depth);
         if (book == null) return NotFound();
-        return Ok(book);
+
+        var bids = book.b
+            .Where(l => l.Length >= 2 && l[1] > 0)
+            .Select(l => new Level { Price = l[0], Size = l[1] })
+            .OrderByDescending(l => l.Price)
+            .ToList();
+        var asks = book.a
+            .Where(l => l.Length >= 2 && l[1] > 0)
+            .Select(l => new Level { Price = l[0], Size = l[1] })
+            .OrderBy(l => l.Price)
+            .ToList();
+
+        var dto = new OrderBookDto
+        {
+            Symbol = norm,
+            Ts = book.t,
+            Bids = bids,
+            Asks = asks,
+            Depth = Math.Max(bids.Count, asks.Count)
+        };
+        return Ok(dto);
     }
 }

--- a/src/Api/Controllers/ProfileController.cs
+++ b/src/Api/Controllers/ProfileController.cs
@@ -1,0 +1,29 @@
+using Domain.DTOs;
+using Domain.Services;
+using Infrastructure.Clients;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[ApiExplorerSettings(GroupName = "Market")]
+public class ProfileController : ControllerBase
+{
+    private readonly IFinnhubClient _client;
+    public ProfileController(IFinnhubClient client) { _client = client; }
+
+    /// <summary>Returns basic company profile data.</summary>
+    [HttpGet("{symbol}")]
+    [SwaggerOperation(Summary = "Returns basic company profile data.")]
+    [ProducesResponseType(typeof(FinnhubCompanyProfileDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<FinnhubCompanyProfileDto>> Get(string symbol)
+    {
+        var norm = SymbolNormalizer.Normalize(symbol);
+        var profile = await _client.GetProfileAsync(norm);
+        if (profile == null) return NotFound();
+        return Ok(profile);
+    }
+}

--- a/src/Api/Controllers/QuotesController.cs
+++ b/src/Api/Controllers/QuotesController.cs
@@ -5,6 +5,7 @@ using Domain.DTOs;
 using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Filters;
 using Api.SwaggerExamples;
+using System.Linq;
 
 namespace Api.Controllers;
 
@@ -22,12 +23,26 @@ public class QuotesController : ControllerBase
     /// <returns>A collection of quotes keyed by symbol.</returns>
     [HttpGet]
     [SwaggerOperation(Summary = "Gets the latest quotes for all tracked symbols.")]
-    [ProducesResponseType(typeof(Dictionary<string, FinnhubQuoteDto>), StatusCodes.Status200OK)]
-    [SwaggerResponse(StatusCodes.Status200OK, "Quotes keyed by symbol", typeof(Dictionary<string, FinnhubQuoteDto>))]
+    [ProducesResponseType(typeof(Dictionary<string, SnapshotDto>), StatusCodes.Status200OK)]
+    [SwaggerResponse(StatusCodes.Status200OK, "Quotes keyed by symbol", typeof(Dictionary<string, SnapshotDto>))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(QuotesExample))]
     public IActionResult GetQuotes()
     {
-        return Ok(FinnhubRestService.LatestQuotes);
+        var mapped = FinnhubRestService.LatestQuotes.ToDictionary(
+            kv => kv.Key,
+            kv => new SnapshotDto
+            {
+                Symbol = kv.Key,
+                Last = kv.Value.c,
+                Bid = 0,
+                Ask = 0,
+                Open = kv.Value.o,
+                High = kv.Value.h,
+                Low = kv.Value.l,
+                PrevClose = kv.Value.pc,
+                Ts = kv.Value.t
+            });
+        return Ok(mapped);
     }
 
     /// <summary>
@@ -37,16 +52,28 @@ public class QuotesController : ControllerBase
     /// <returns>The latest quote if available.</returns>
     [HttpGet("{symbol}")]
     [SwaggerOperation(Summary = "Gets the latest quote for a specified symbol.")]
-    [ProducesResponseType(typeof(FinnhubQuoteDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(SnapshotDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [SwaggerResponse(StatusCodes.Status200OK, "Latest quote", typeof(FinnhubQuoteDto))]
+    [SwaggerResponse(StatusCodes.Status200OK, "Latest quote", typeof(SnapshotDto))]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Quote not found")]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(QuoteExample))]
     public IActionResult GetQuote(string symbol)
     {
         if (FinnhubRestService.LatestQuotes.TryGetValue(symbol, out var quote))
         {
-            return Ok(quote);
+            var dto = new SnapshotDto
+            {
+                Symbol = symbol,
+                Last = quote.c,
+                Bid = 0,
+                Ask = 0,
+                Open = quote.o,
+                High = quote.h,
+                Low = quote.l,
+                PrevClose = quote.pc,
+                Ts = quote.t
+            };
+            return Ok(dto);
         }
         return NotFound();
     }

--- a/src/Api/Controllers/SymbolsController.cs
+++ b/src/Api/Controllers/SymbolsController.cs
@@ -1,0 +1,28 @@
+using Domain.DTOs;
+using Infrastructure.Clients;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// Discover symbols for an exchange.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[ApiExplorerSettings(GroupName = "Market")]
+public class SymbolsController : ControllerBase
+{
+    private readonly IFinnhubClient _client;
+    public SymbolsController(IFinnhubClient client) { _client = client; }
+
+    /// <summary>Returns available symbols for an exchange.</summary>
+    [HttpGet]
+    [SwaggerOperation(Summary = "Returns available symbols for an exchange.")]
+    [ProducesResponseType(typeof(IEnumerable<FinnhubSymbolDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<FinnhubSymbolDto>>> Get([FromQuery] string exchange)
+    {
+        var symbols = await _client.GetSymbolsAsync(exchange);
+        return Ok(symbols);
+    }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -39,6 +39,7 @@ builder.Services.AddControllers();
 builder.Services.AddSignalR();
 builder.Services.AddHttpClient<FinnhubRestService>();
 builder.Services.AddHostedService<FinnhubRestService>();
+builder.Services.Configure<FinnhubOptions>(builder.Configuration.GetSection("Finnhub"));
 builder.Services.AddHttpClient<IFinnhubClient, FinnhubClient>();
 builder.Services.AddCors(options =>
 {

--- a/src/Api/SwaggerExamples/MarketExamples.cs
+++ b/src/Api/SwaggerExamples/MarketExamples.cs
@@ -1,62 +1,66 @@
 using Domain.DTOs;
 using Swashbuckle.AspNetCore.Filters;
+using System.Collections.Generic;
 
 namespace Api.SwaggerExamples;
 
-public class QuotesExample : IExamplesProvider<Dictionary<string, FinnhubQuoteDto>>
+public class QuotesExample : IExamplesProvider<Dictionary<string, SnapshotDto>>
 {
-    public Dictionary<string, FinnhubQuoteDto> GetExamples() => new()
+    public Dictionary<string, SnapshotDto> GetExamples() => new()
     {
-        ["AAPL"] = new FinnhubQuoteDto
+        ["AAPL"] = new SnapshotDto
         {
-            c = 150.12m,
-            h = 155.00m,
-            l = 149.50m,
-            o = 152.30m,
-            pc = 151.80m,
-            t = 1700000000
+            Symbol = "AAPL",
+            Last = 150.12m,
+            Bid = 150.00m,
+            Ask = 150.20m,
+            Open = 152.30m,
+            High = 155.00m,
+            Low = 149.50m,
+            PrevClose = 151.80m,
+            Ts = 1700000000
         }
     };
 }
 
-public class QuoteExample : IExamplesProvider<FinnhubQuoteDto>
+public class QuoteExample : IExamplesProvider<SnapshotDto>
 {
-    public FinnhubQuoteDto GetExamples() => new()
+    public SnapshotDto GetExamples() => new()
     {
-        c = 150.12m,
-        h = 155.00m,
-        l = 149.50m,
-        o = 152.30m,
-        pc = 151.80m,
-        t = 1700000000
+        Symbol = "AAPL",
+        Last = 150.12m,
+        Bid = 150.00m,
+        Ask = 150.20m,
+        Open = 152.30m,
+        High = 155.00m,
+        Low = 149.50m,
+        PrevClose = 151.80m,
+        Ts = 1700000000
     };
 }
 
-public class OrderBookExample : IExamplesProvider<FinnhubOrderBookDto>
+public class OrderBookExample : IExamplesProvider<OrderBookDto>
 {
-    public FinnhubOrderBookDto GetExamples() => new()
+    public OrderBookDto GetExamples() => new()
     {
-        s = "AAPL",
-        t = 1700000000,
-        b = new[] { new[] { 150.00m, 100m } },
-        a = new[] { new[] { 150.50m, 80m } }
+        Symbol = "AAPL",
+        Ts = 1700000000,
+        Bids = new() { new Level { Price = 150.00m, Size = 100m } },
+        Asks = new() { new Level { Price = 150.50m, Size = 80m } },
+        Depth = 1
     };
 }
 
-public class TradesExample : IExamplesProvider<FinnhubTradeDto>
+public class TradesExample : IExamplesProvider<IEnumerable<TradeDto>>
 {
-    public FinnhubTradeDto GetExamples() => new()
+    public IEnumerable<TradeDto> GetExamples() => new[]
     {
-        s = "AAPL",
-        data = new[]
+        new TradeDto
         {
-            new FinnhubTradeTick
-            {
-                p = 150.10m,
-                v = 50m,
-                t = 1700000000,
-                c = new[] { "@", "T" }
-            }
+            Symbol = "AAPL",
+            Price = 150.10m,
+            Size = 50m,
+            Ts = 1700000000
         }
     };
 }

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Finnhub": {
+    "RestBaseUrl": "https://finnhub.io/api/v1/",
+    "WebSocketUrl": "wss://ws.finnhub.io"
   }
 }

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -6,4 +6,9 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "Finnhub": {
+    "RestBaseUrl": "https://finnhub.io/api/v1/",
+    "WebSocketUrl": "wss://ws.finnhub.io"
+  }
 }

--- a/src/Domain/DTOs/FinnhubCandleDto.cs
+++ b/src/Domain/DTOs/FinnhubCandleDto.cs
@@ -1,0 +1,12 @@
+namespace Domain.DTOs;
+
+/// <summary>Represents OHLC candle data from Finnhub.</summary>
+public class FinnhubCandleDto
+{
+    public IEnumerable<decimal> c { get; set; } = Enumerable.Empty<decimal>();
+    public IEnumerable<decimal> h { get; set; } = Enumerable.Empty<decimal>();
+    public IEnumerable<decimal> l { get; set; } = Enumerable.Empty<decimal>();
+    public IEnumerable<decimal> o { get; set; } = Enumerable.Empty<decimal>();
+    public IEnumerable<long> t { get; set; } = Enumerable.Empty<long>();
+    public string s { get; set; } = string.Empty;
+}

--- a/src/Domain/DTOs/FinnhubCompanyProfileDto.cs
+++ b/src/Domain/DTOs/FinnhubCompanyProfileDto.cs
@@ -1,0 +1,10 @@
+namespace Domain.DTOs;
+
+/// <summary>Company profile basic information.</summary>
+public class FinnhubCompanyProfileDto
+{
+    public string ticker { get; set; } = string.Empty;
+    public string name { get; set; } = string.Empty;
+    public string? currency { get; set; }
+    public string? exchange { get; set; }
+}

--- a/src/Domain/DTOs/FinnhubSymbolDto.cs
+++ b/src/Domain/DTOs/FinnhubSymbolDto.cs
@@ -1,0 +1,9 @@
+namespace Domain.DTOs;
+
+/// <summary>Represents a tradeable instrument returned from Finnhub.</summary>
+public class FinnhubSymbolDto
+{
+    public string symbol { get; set; } = string.Empty;
+    public string description { get; set; } = string.Empty;
+    public string? exchange { get; set; }
+}

--- a/src/Domain/DTOs/OrderBookDto.cs
+++ b/src/Domain/DTOs/OrderBookDto.cs
@@ -1,0 +1,31 @@
+namespace Domain.DTOs;
+
+/// <summary>
+/// Standardized order book representation for downstream clients.
+/// </summary>
+public class OrderBookDto
+{
+    /// <summary>Normalized symbol (e.g. NASDAQ:AAPL).</summary>
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <summary>Server timestamp in unix milliseconds.</summary>
+    public long Ts { get; set; }
+
+    /// <summary>Bids sorted descending by price.</summary>
+    public List<Level> Bids { get; set; } = new();
+
+    /// <summary>Asks sorted ascending by price.</summary>
+    public List<Level> Asks { get; set; } = new();
+
+    /// <summary>Depth actually returned.</summary>
+    public int Depth { get; set; }
+}
+
+/// <summary>
+/// Price level information.
+/// </summary>
+public class Level
+{
+    public decimal Price { get; set; }
+    public decimal Size { get; set; }
+}

--- a/src/Domain/DTOs/SnapshotDto.cs
+++ b/src/Domain/DTOs/SnapshotDto.cs
@@ -1,0 +1,17 @@
+namespace Domain.DTOs;
+
+/// <summary>
+/// Lightweight quote snapshot.
+/// </summary>
+public class SnapshotDto
+{
+    public string Symbol { get; set; } = string.Empty;
+    public decimal Last { get; set; }
+    public decimal Bid { get; set; }
+    public decimal Ask { get; set; }
+    public decimal? Open { get; set; }
+    public decimal? High { get; set; }
+    public decimal? Low { get; set; }
+    public decimal? PrevClose { get; set; }
+    public long Ts { get; set; }
+}

--- a/src/Domain/DTOs/TradeDto.cs
+++ b/src/Domain/DTOs/TradeDto.cs
@@ -1,0 +1,14 @@
+namespace Domain.DTOs;
+
+/// <summary>
+/// Represents a normalized trade tick.
+/// </summary>
+public class TradeDto
+{
+    public string Symbol { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public decimal Size { get; set; }
+    public string? Side { get; set; }
+    /// <summary>Unix timestamp in milliseconds.</summary>
+    public long Ts { get; set; }
+}

--- a/src/Domain/Services/SymbolNormalizer.cs
+++ b/src/Domain/Services/SymbolNormalizer.cs
@@ -1,0 +1,13 @@
+namespace Domain.Services;
+
+/// <summary>
+/// Provides helpers for symbol normalization.
+/// </summary>
+public static class SymbolNormalizer
+{
+    /// <summary>
+    /// Normalize a user supplied symbol to uppercase and trims whitespace.
+    /// </summary>
+    public static string Normalize(string raw)
+        => string.IsNullOrWhiteSpace(raw) ? string.Empty : raw.Trim().ToUpperInvariant();
+}

--- a/src/Infrastructure/Clients/FinnhubClient.cs
+++ b/src/Infrastructure/Clients/FinnhubClient.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using Domain.DTOs;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using System.Linq;
 
 namespace Infrastructure.Clients;
 
@@ -10,32 +11,51 @@ namespace Infrastructure.Clients;
 public class FinnhubClient : IFinnhubClient
 {
     private readonly HttpClient _httpClient;
-    private readonly string _apiKey;
+    private readonly FinnhubOptions _options;
 
-    public FinnhubClient(HttpClient httpClient, IConfiguration configuration)
+    public FinnhubClient(HttpClient httpClient, IOptions<FinnhubOptions> options)
     {
         _httpClient = httpClient;
-        _apiKey = configuration["FINNHUB_API_KEY"] ?? string.Empty;
-        _httpClient.BaseAddress = new Uri("https://finnhub.io/api/v1/");
+        _options = options.Value;
+        _httpClient.BaseAddress = new Uri(_options.RestBaseUrl);
     }
 
     public async Task<FinnhubOrderBookDto?> GetOrderBookAsync(string symbol, int? depth = null, CancellationToken ct = default)
     {
-        var url = $"orderbook?symbol={symbol}&token={_apiKey}";
+        var url = $"orderbook?symbol={symbol}&token={_options.ApiKey}";
         if (depth.HasValue) url += $"&depth={depth.Value}";
         return await _httpClient.GetFromJsonAsync<FinnhubOrderBookDto>(url, ct);
     }
 
     public async Task<FinnhubTradeDto?> GetTradesAsync(string symbol, DateTime from, DateTime to, int? limit = null, CancellationToken ct = default)
     {
-        var url = $"stock/trades?symbol={symbol}&from={from:yyyy-MM-dd}&to={to:yyyy-MM-dd}&token={_apiKey}";
+        var url = $"stock/trades?symbol={symbol}&from={from:yyyy-MM-dd}&to={to:yyyy-MM-dd}&token={_options.ApiKey}";
         if (limit.HasValue) url += $"&limit={limit.Value}";
         return await _httpClient.GetFromJsonAsync<FinnhubTradeDto>(url, ct);
     }
 
     public Task<FinnhubQuoteDto?> GetQuoteAsync(string symbol, CancellationToken ct = default)
     {
-        var url = $"quote?symbol={symbol}&token={_apiKey}";
+        var url = $"quote?symbol={symbol}&token={_options.ApiKey}";
         return _httpClient.GetFromJsonAsync<FinnhubQuoteDto>(url, ct);
+    }
+
+    public Task<FinnhubCandleDto?> GetCandlesAsync(string symbol, string resolution, DateTime from, DateTime to, CancellationToken ct = default)
+    {
+        var url = $"stock/candle?symbol={symbol}&resolution={resolution}&from={new DateTimeOffset(from).ToUnixTimeSeconds()}&to={new DateTimeOffset(to).ToUnixTimeSeconds()}&token={_options.ApiKey}";
+        return _httpClient.GetFromJsonAsync<FinnhubCandleDto>(url, ct);
+    }
+
+    public Task<FinnhubCompanyProfileDto?> GetProfileAsync(string symbol, CancellationToken ct = default)
+    {
+        var url = $"stock/profile2?symbol={symbol}&token={_options.ApiKey}";
+        return _httpClient.GetFromJsonAsync<FinnhubCompanyProfileDto>(url, ct);
+    }
+
+    public async Task<IEnumerable<FinnhubSymbolDto>> GetSymbolsAsync(string exchange, CancellationToken ct = default)
+    {
+        var url = $"stock/symbol?exchange={exchange}&token={_options.ApiKey}";
+        return await _httpClient.GetFromJsonAsync<IEnumerable<FinnhubSymbolDto>>(url, ct) 
+               ?? Enumerable.Empty<FinnhubSymbolDto>();
     }
 }

--- a/src/Infrastructure/Clients/FinnhubOptions.cs
+++ b/src/Infrastructure/Clients/FinnhubOptions.cs
@@ -1,0 +1,11 @@
+namespace Infrastructure.Clients;
+
+/// <summary>
+/// Configuration for Finnhub service.
+/// </summary>
+public class FinnhubOptions
+{
+    public string ApiKey { get; set; } = string.Empty;
+    public string RestBaseUrl { get; set; } = "https://finnhub.io/api/v1/";
+    public string WebSocketUrl { get; set; } = "wss://ws.finnhub.io";
+}

--- a/src/Infrastructure/Clients/IFinnhubClient.cs
+++ b/src/Infrastructure/Clients/IFinnhubClient.cs
@@ -7,4 +7,7 @@ public interface IFinnhubClient
     Task<FinnhubOrderBookDto?> GetOrderBookAsync(string symbol, int? depth = null, CancellationToken ct = default);
     Task<FinnhubTradeDto?> GetTradesAsync(string symbol, DateTime from, DateTime to, int? limit = null, CancellationToken ct = default);
     Task<FinnhubQuoteDto?> GetQuoteAsync(string symbol, CancellationToken ct = default);
+    Task<FinnhubCandleDto?> GetCandlesAsync(string symbol, string resolution, DateTime from, DateTime to, CancellationToken ct = default);
+    Task<FinnhubCompanyProfileDto?> GetProfileAsync(string symbol, CancellationToken ct = default);
+    Task<IEnumerable<FinnhubSymbolDto>> GetSymbolsAsync(string exchange, CancellationToken ct = default);
 }

--- a/tests/ApiTests/MarketControllersTests.cs
+++ b/tests/ApiTests/MarketControllersTests.cs
@@ -8,11 +8,22 @@ using Xunit;
 class FakeFinnhubClient : IFinnhubClient
 {
     public Task<FinnhubOrderBookDto?> GetOrderBookAsync(string symbol, int? depth = null, CancellationToken ct = default)
-        => Task.FromResult<FinnhubOrderBookDto?>(new FinnhubOrderBookDto());
+        => Task.FromResult<FinnhubOrderBookDto?>(new FinnhubOrderBookDto
+        {
+            t = 1,
+            b = new[] { new[] { 1m, 1m } },
+            a = new[] { new[] { 2m, 1m } }
+        });
     public Task<FinnhubTradeDto?> GetTradesAsync(string symbol, DateTime from, DateTime to, int? limit = null, CancellationToken ct = default)
         => Task.FromResult<FinnhubTradeDto?>(new FinnhubTradeDto());
     public Task<FinnhubQuoteDto?> GetQuoteAsync(string symbol, CancellationToken ct = default)
         => Task.FromResult<FinnhubQuoteDto?>(new FinnhubQuoteDto());
+    public Task<FinnhubCandleDto?> GetCandlesAsync(string symbol, string resolution, DateTime from, DateTime to, CancellationToken ct = default)
+        => Task.FromResult<FinnhubCandleDto?>(new FinnhubCandleDto());
+    public Task<FinnhubCompanyProfileDto?> GetProfileAsync(string symbol, CancellationToken ct = default)
+        => Task.FromResult<FinnhubCompanyProfileDto?>(new FinnhubCompanyProfileDto());
+    public Task<IEnumerable<FinnhubSymbolDto>> GetSymbolsAsync(string exchange, CancellationToken ct = default)
+        => Task.FromResult<IEnumerable<FinnhubSymbolDto>>(Array.Empty<FinnhubSymbolDto>());
 }
 
 public class MarketControllersTests
@@ -22,6 +33,7 @@ public class MarketControllersTests
     {
         var controller = new OrderBookController(new FakeFinnhubClient());
         var result = await controller.Get("AAPL", null);
-        Assert.IsType<OkObjectResult>(result.Result);
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsType<OrderBookDto>(ok.Value);
     }
 }


### PR DESCRIPTION
## Summary
- add FinnhubOptions and bind via Program
- normalize symbols and map Finnhub responses to local DTOs
- expose candles, profile and symbol discovery endpoints

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6898bf05da48832b80624119fc4d1422