### PR TITLE
Expose all controllers in Swagger

### DIFF
--- a/src/Api/Controllers/CandlesController.cs
+++ b/src/Api/Controllers/CandlesController.cs
@@ -8,7 +8,6 @@ namespace Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[ApiExplorerSettings(GroupName = "Market")]
 public class CandlesController : ControllerBase
 {
     private readonly IFinnhubClient _client;

--- a/src/Api/Controllers/OrderBookController.cs
+++ b/src/Api/Controllers/OrderBookController.cs
@@ -14,7 +14,6 @@ namespace Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-[ApiExplorerSettings(GroupName = "Market")]
 public class OrderBookController : ControllerBase
 {
     private readonly IFinnhubClient _client;

--- a/src/Api/Controllers/ProfileController.cs
+++ b/src/Api/Controllers/ProfileController.cs
@@ -8,7 +8,6 @@ namespace Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[ApiExplorerSettings(GroupName = "Market")]
 public class ProfileController : ControllerBase
 {
     private readonly IFinnhubClient _client;

--- a/src/Api/Controllers/QuotesController.cs
+++ b/src/Api/Controllers/QuotesController.cs
@@ -15,7 +15,6 @@ namespace Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-[ApiExplorerSettings(GroupName = "Quotes")]
 public class QuotesController : ControllerBase
 {
     /// <summary>

--- a/src/Api/Controllers/SnapshotController.cs
+++ b/src/Api/Controllers/SnapshotController.cs
@@ -14,7 +14,6 @@ namespace Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-[ApiExplorerSettings(GroupName = "Market")]
 public class SnapshotController : ControllerBase
 {
     private readonly IFinnhubClient _client;

--- a/src/Api/Controllers/SymbolsController.cs
+++ b/src/Api/Controllers/SymbolsController.cs
@@ -11,7 +11,6 @@ namespace Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-[ApiExplorerSettings(GroupName = "Market")]
 public class SymbolsController : ControllerBase
 {
     private readonly IFinnhubClient _client;

--- a/src/Api/Controllers/TradesController.cs
+++ b/src/Api/Controllers/TradesController.cs
@@ -14,7 +14,6 @@ namespace Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-[ApiExplorerSettings(GroupName = "Market")]
 public class TradesController : ControllerBase
 {
     private readonly IFinnhubClient _client;

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -27,17 +27,10 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {
     options.SwaggerDoc("v1", new OpenApiInfo { Title = "SwissTax API", Version = "v1" });
-    options.SwaggerDoc("Market", new OpenApiInfo { Title = "Market API", Version = "v1" });
-    options.SwaggerDoc("Quotes", new OpenApiInfo { Title = "Quotes API", Version = "v1" });
     var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
     options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
     options.EnableAnnotations();
     options.ExampleFilters();
-    options.DocInclusionPredicate((docName, apiDesc) =>
-    {
-        var groupName = apiDesc.GroupName ?? "v1";
-        return groupName == docName;
-    });
 });
 builder.Services.AddSwaggerExamplesFromAssemblyOf<QuoteExample>();
 builder.Services.AddFluentValidationAutoValidation();
@@ -64,8 +57,6 @@ app.UseSwagger();
 app.UseSwaggerUI(options =>
 {
     options.SwaggerEndpoint("/swagger/v1/swagger.json", "SwissTax API");
-    options.SwaggerEndpoint("/swagger/Market/swagger.json", "Market API");
-    options.SwaggerEndpoint("/swagger/Quotes/swagger.json", "Quotes API");
 });
 app.UseCors();
 


### PR DESCRIPTION
## Summary
- simplify Swagger to use single document
- expose market and quotes controllers in Swagger UI

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b330bfbf8832ba22fb30e1475559c