### PR TITLE
Stop perpetual polling loops

### DIFF
--- a/src/Api/Background/FinnhubRestService.cs
+++ b/src/Api/Background/FinnhubRestService.cs
@@ -64,19 +64,22 @@ public class FinnhubRestService : BackgroundService
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Starting sequential polling respecting rate limits.");
-        while (!stoppingToken.IsCancellationRequested)
+        foreach (var symbol in _symbols)
         {
-            foreach (var symbol in _symbols)
+            if (stoppingToken.IsCancellationRequested)
             {
-                await PollFinnhubAsync(symbol, stoppingToken);
-                try
-                {
-                    await Task.Delay(_requestInterval, stoppingToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    break;
-                }
+                break;
+            }
+
+            await PollFinnhubAsync(symbol, stoppingToken);
+
+            try
+            {
+                await Task.Delay(_requestInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
             }
         }
     }

--- a/src/Worker/Worker.cs
+++ b/src/Worker/Worker.cs
@@ -11,13 +11,11 @@ public class Worker : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        if (_logger.IsEnabled(LogLevel.Information))
         {
-            if (_logger.IsEnabled(LogLevel.Information))
-            {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-            }
-            await Task.Delay(1000, stoppingToken);
+            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
         }
+
+        await Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- Stop infinite polling by processing configured symbols once in FinnhubRestService
- Make Worker log once and then complete

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689b391485b8832ba1ab681c1045dcd1