### PR TITLE
Add script to export API spec

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "swashbuckle.aspnetcore.cli": {
+      "version": "9.0.3",
+      "commands": [
+        "swagger"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ dotnet build SwissTax.sln
 dotnet test
 ```
 
+## Export API specification
+
+Generate the OpenAPI description without running the server:
+
+```bash
+./scripts/export-spec.sh openapi.json
+```
+
+The specification will be written to `openapi.json` in the repository root. The script requires the local `Swashbuckle.AspNetCore.Cli` tool, which is restored automatically.
+
 ## Docker
 
 Build and run locally:

--- a/scripts/export-spec.sh
+++ b/scripts/export-spec.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the API project
+DOTNET_ROOT=${DOTNET_ROOT:-/usr/share/dotnet}
+export PATH="$DOTNET_ROOT:$PATH"
+
+# Restore local tools
+if [ -f ".config/dotnet-tools.json" ]; then
+  dotnet tool restore >/dev/null
+fi
+
+# Build the API project
+if [ ! -f "src/Api/bin/Release/net8.0/Api.dll" ]; then
+  dotnet build src/Api/Api.csproj -c Release >/dev/null
+fi
+
+# Generate the OpenAPI specification to swagger.json
+OUTPUT_FILE=${1:-swagger.json}
+dotnet tool run swagger tofile --output "$OUTPUT_FILE" src/Api/bin/Release/net8.0/Api.dll v1
+
+echo "OpenAPI specification written to $OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- add a local Swashbuckle CLI tool and script to generate the OpenAPI spec
- document how to export the API specification

## Testing
- `./scripts/export-spec.sh`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b47302320832b94b63a51649ecdc3